### PR TITLE
Add variable substitution to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       context: ./resultsmanager
     environment:
       #Change to fhir data provider within the internal EHR
-      CQL_EXECUTION_DATA_SERVICE: "https://apps.hdap.gatech.edu/gt-fhir/fhir/"
+      CQL_EXECUTION_DATA_SERVICE: "${CQL_EXECUTION_DATA_SERVICE:-https://apps.hdap.gatech.edu/gt-fhir/fhir/}"
       #Basic authentication credentials to the data service
       CQL_EXECUTION_DATA_USER: ""
       CQL_EXECUTION_DATA_PASS: ""


### PR DESCRIPTION
Hi, Michael from OCHIN again

What do you think about adding [variable substitution](https://docs.docker.com/compose/compose-file/#variable-substitution) to the `docker-compose.yml` in this repo?

You can add a default to fall back on if the environmental isn't set so it shouldn't affect any existing implementations

Seems like it could be a good way for consumers to easily configure the server

I ended up using CloudFormation to launch the instance and this syntax worked pretty well to pull configuration from the instance into the container

thanks!
michael